### PR TITLE
feat(resolver) Add custom module resolver approach.

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,21 @@ Choose your module management approach:
 
 ```php
 'modules' => [
-    'approach' => env('MODULITE_APPROACH', 'panicdevs'), // or 'nwidart'
+    'approach' => env('MODULITE_APPROACH', 'panicdevs'), // or 'nwidart' or custom FQCN
+    'scan_only_enabled' => true,
+    'respect_module_priority' => true,
+],
+```
+
+### Custom Module Resolver (FQCN)
+
+You can provide your own fully-qualified class name (FQCN) as the module approach.
+Your class **must implement** the `PanicDevs\Modulite\Contracts\ModuleResolverInterface`.
+
+```php
+// config/modulite.php
+'modules' => [
+    'approach' => \App\CustomModuleResolver::class,
     'scan_only_enabled' => true,
     'respect_module_priority' => true,
 ],
@@ -367,7 +381,7 @@ public function panel(Panel $panel): Panel
         ]);
 }
 
-// ManagerPanelProvider.php  
+// ManagerPanelProvider.php
 public function panel(Panel $panel): Panel
 {
     return $panel

--- a/config/modulite.php
+++ b/config/modulite.php
@@ -388,10 +388,13 @@ return [
         |--------------------------------------------------------------------------
         |
         | Specify which module management system you're using:
-        | - 'nwidart': Use nwidart/laravel-modules package
-        | - 'panicdevs': Use panicdevs/modules package
+        | - 'nwidart'   : Use nwidart/laravel-modules package
+        | - 'panicdevs' : Use panicdevs/modules package
+        | - custom      : Provide your own custom implementation class
+        |                 (must implement PanicDevs\Modulite\Contracts\ModuleResolverInterface).
         |
-        | This determines how Modulite discovers and interacts with your modules.
+        | Example:
+        | 'approach' => \App\CustomModuleResolver::class,
         |
         */
         'approach' => env('MODULITE_APPROACH', 'panicdevs'),

--- a/src/Actions/CreateModuleResolver.php
+++ b/src/Actions/CreateModuleResolver.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace PanicDevs\Modulite\Actions;
+
+use Illuminate\Contracts\Foundation\Application;
+use PanicDevs\Modulite\Contracts\ModuleResolverInterface;
+use PanicDevs\Modulite\Services\ModuleResolvers\NwidartModuleResolver;
+use PanicDevs\Modulite\Services\ModuleResolvers\PanicDevsModuleResolver;
+
+final class CreateModuleResolver
+{
+    public function handle(Application $app): ModuleResolverInterface
+    {
+        $approach = $app['config']->get('modulite.modules.approach');
+
+        $defaultApproach = static::getDefaultApproach();
+
+        $class = !($defaultApproach[$approach] ?? '') ?
+            (static::approachIsResolvable($approach) ?
+                $approach :
+                throw new \Exception(
+                    "Configured module approach [{$approach}] is missing or not resolvable."
+                )) :
+            $defaultApproach[$approach];
+
+        return $app->make($class);
+    }
+
+    private static function approachIsResolvable(string $approach): bool
+    {
+        return
+            class_exists($approach) &&
+            is_subclass_of($approach, ModuleResolverInterface::class);
+    }
+
+    private static function getDefaultApproach(): array
+    {
+        return [
+            'panicdevs' => PanicDevsModuleResolver::class,
+            'nwidart'   => nwidartModuleResolver::class,
+        ];
+    }
+}

--- a/src/Console/Commands/ModuliteOptimizeCommand.php
+++ b/src/Console/Commands/ModuliteOptimizeCommand.php
@@ -167,7 +167,7 @@ class ModuliteOptimizeCommand extends Command
         $moduleData = $enabledModules->sort()->values()->toArray();
 
         // Include the module resolver approach in cache key
-        $approach = config('modulite.modules.approach', 'nwidart');
+        $approach = config('modulite.modules.approach');
 
         // Include configuration in cache key
         $configHash = md5(serialize([

--- a/src/Console/Commands/ModuliteStatusCommand.php
+++ b/src/Console/Commands/ModuliteStatusCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PanicDevs\Modulite\Console\Commands;
 
 use Illuminate\Console\Command;
+use PanicDevs\Modulite\Contracts\ModuleResolverInterface;
 use PanicDevs\Modulite\Contracts\PanelScannerInterface;
 
 /**
@@ -40,7 +41,7 @@ class ModuliteStatusCommand extends Command
 
         // Display status
         $this->displayConfiguration();
-        $this->displayModuleStatus($panelScanner);
+        $this->displayModuleStatus();
         $this->displayPanelStatus($panelScanner);
         $this->displayComponentStatus($componentScanner);
         $this->displayCacheStatus($cache);
@@ -101,32 +102,21 @@ class ModuliteStatusCommand extends Command
         $this->newLine();
     }
 
-    protected function displayModuleStatus(PanelScannerInterface $panelScanner): void
+    protected function displayModuleStatus(): void
     {
         $this->info('Module Status:');
 
-        // Get enabled modules using nwidart modules if available
-        $enabledModules = collect();
+        $enabledModules = app(ModuleResolverInterface::class)->getEnabledModules();
 
-        if (class_exists(\Nwidart\Modules\Facades\Module::class))
-        {
-            $enabledModulesArray = \Nwidart\Modules\Facades\Module::allEnabled();
-            foreach ($enabledModulesArray as $module)
-            {
-                $enabledModules->push($module->getName());
-            }
+        if ($enabledModules->isEmpty()){
+            $this->warn('No enabled modules found');
+            return;
         }
 
-        if ($enabledModules->isEmpty())
-        {
-            $this->warn('No enabled modules found');
-        } else
-        {
-            $this->info("Found {$enabledModules->count()} enabled modules:");
-            foreach ($enabledModules as $module)
-            {
-                $this->line("  • {$module}");
-            }
+        $this->info("Found {$enabledModules->count()} enabled modules:");
+
+        foreach ($enabledModules as $module) {
+            $this->line("  • {$module}");
         }
 
         $this->newLine();

--- a/src/Contracts/ModuleResolverInterface.php
+++ b/src/Contracts/ModuleResolverInterface.php
@@ -52,4 +52,13 @@ interface ModuleResolverInterface
      * @return bool True if system is available, false otherwise
      */
     public function isAvailable(): bool;
+
+    /**
+     * Determine whether panels should be registered
+     * before Filament initialization.
+     *
+     * @return bool True if panels must be registered before Filament
+     */
+    public function shouldRegisterPanelsBeforeFilament(): bool;
+
 }

--- a/src/Providers/ModuliteServiceProvider.php
+++ b/src/Providers/ModuliteServiceProvider.php
@@ -8,6 +8,7 @@ use Filament\FilamentServiceProvider;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
+use PanicDevs\Modulite\Actions\CreateModuleResolver;
 use PanicDevs\Modulite\Console\Commands\ModuliteClearCacheCommand;
 use PanicDevs\Modulite\Console\Commands\ModuliteStatusCommand;
 use PanicDevs\Modulite\Console\Commands\ModuliteOptimizeCommand;
@@ -16,8 +17,6 @@ use PanicDevs\Modulite\Contracts\ComponentScannerInterface;
 use PanicDevs\Modulite\Contracts\ModuleResolverInterface;
 use PanicDevs\Modulite\Contracts\PanelScannerInterface;
 use PanicDevs\Modulite\Services\ComponentDiscoveryService;
-use PanicDevs\Modulite\Services\ModuleResolvers\NwidartModuleResolver;
-use PanicDevs\Modulite\Services\ModuleResolvers\PanicDevsModuleResolver;
 use PanicDevs\Modulite\Services\PanelScannerService;
 use PanicDevs\Modulite\Services\UnifiedCacheManager;
 use Throwable;
@@ -78,14 +77,15 @@ class ModuliteServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->registerConfiguration();
+
         $this->registerCoreServices();
-        if ('nwidart' === config('modulite.modules.approach'))
-        {
-            $this->app->beforeResolving('filament', fn() => $this->registerPanelDiscovery());
-        } else
-        {
-            $this->registerPanelDiscovery();
-        }
+
+        $this->app
+            ->make(ModuleResolverInterface::class)
+            ->shouldRegisterPanelsBeforeFilament() ?
+                $this->app->beforeResolving('filament', fn () => $this->registerPanelDiscovery()):
+                $this->registerPanelDiscovery();
+
         $this->registerCacheInvalidationListeners();
     }
 
@@ -126,7 +126,10 @@ class ModuliteServiceProvider extends ServiceProvider
         });
 
         // Register ModuleResolver based on configuration
-        $this->app->singleton(ModuleResolverInterface::class, fn(Application $app) => $this->createModuleResolver($app));
+        $this->app->singleton(
+            ModuleResolverInterface::class,
+            fn(Application $app) => (new CreateModuleResolver())->handle($app)
+        );
 
         // Register PanelScannerService with dependencies
         $this->app->singleton(PanelScannerInterface::class, function (Application $app)
@@ -244,7 +247,7 @@ class ModuliteServiceProvider extends ServiceProvider
         $moduleData = $enabledModules->sort()->values()->toArray();
 
         // Include the module resolver approach in cache key
-        $approach = config('modulite.modules.approach', 'nwidart');
+        $approach = config('modulite.modules.approach');
 
         // Include configuration in cache key
         $configHash = md5(serialize([
@@ -280,21 +283,6 @@ class ModuliteServiceProvider extends ServiceProvider
         {
             return null;
         }
-    }
-
-    /**
-     * Create the appropriate module resolver based on configuration.
-     */
-    protected function createModuleResolver(Application $app): ModuleResolverInterface
-    {
-        $approach = $app['config']->get('modulite.modules.approach', 'nwidart');
-
-        return match ($approach)
-        {
-            'panicdevs' => new PanicDevsModuleResolver($app),
-            'nwidart'   => new NwidartModuleResolver(),
-            default     => new NwidartModuleResolver(), // Default fallback
-        };
     }
 
     /**

--- a/src/Services/ModuleResolvers/NwidartModuleResolver.php
+++ b/src/Services/ModuleResolvers/NwidartModuleResolver.php
@@ -154,4 +154,15 @@ class NwidartModuleResolver implements ModuleResolverInterface
 
         return $modules;
     }
+
+    /**
+     * Determine whether panels should be registered
+     * before Filament initialization.
+     *
+     * @return bool True if panels must be registered before Filament
+     */
+    public function shouldRegisterPanelsBeforeFilament(): bool
+    {
+        return true;
+    }
 }

--- a/src/Services/ModuleResolvers/PanicDevsModuleResolver.php
+++ b/src/Services/ModuleResolvers/PanicDevsModuleResolver.php
@@ -144,4 +144,15 @@ class PanicDevsModuleResolver implements ModuleResolverInterface
 
         return $this->moduleService;
     }
+
+    /**
+     * Determine whether panels should be registered
+     * before Filament initialization.
+     *
+     * @return bool True if panels must be registered before Filament
+     */
+    public function shouldRegisterPanelsBeforeFilament(): bool
+    {
+        return false;
+    }
 }


### PR DESCRIPTION
## Summary  
This PR introduces the ability to configure **custom module resolvers** in Modulite.  
Developers can now implement their own module resolution logic by providing a class that implements  
`PanicDevs\Modulite\Contracts\ModuleResolverInterface`.  

## Main Changes: 
- **Config (`config/modulite.php`)**  
  - Updated `modules.approach` to support:
    - `panicdevs` → `PanicDevsModuleResolver`
    - `nwidart` → `NwidartModuleResolver`
    - **custom** → Must implement `ModuleResolverInterface`  

- **Core Service Registration**  
  - Introduced `CreateModuleResolver` action to dynamically resolve module approach.  
  - Refactored hardcoded resolver selection logic.  

- **Console Command Updates (`ModuliteStatusCommand::class`)**  
  - Previously, this command only worked with the **`nwidart` resolver**.  
  - When using `panicdevs` it didn’t return any results.  
  - Now, `displayModuleStatus()` fully relies on `ModuleResolverInterface`.

- **Contracts**  
  - Added `shouldRegisterPanelsBeforeFilament()` to `ModuleResolverInterface`. 
